### PR TITLE
fix for issue #2 in BarrettTechnology/proficio_toolbox repo

### DIFF
--- a/include/barrett/products/gimbals_hand_controller.h
+++ b/include/barrett/products/gimbals_hand_controller.h
@@ -75,7 +75,7 @@ protected:
 
 	static const int KNOB_MIN_VALID = 500;
 	static const int KNOB_MAX_VALID = 2800;
-	static const double COUNTS_PER_RAD = 4096.0 / (2*M_PI);
+	static const double COUNTS_PER_RAD = 4096.0*M_1_PI/2.0;
 
 
 	Puck& p6;


### PR DESCRIPTION
Previous version of gimbals_hand_controller.h would not build with certain compiler options (which are necessary for CGAL library). This version builds on my system, but I would like it to be tested on another system.
